### PR TITLE
Git: Escape SSH askpass passphrases

### DIFF
--- a/airflow-core/newsfragments/63942.bugfix.rst
+++ b/airflow-core/newsfragments/63942.bugfix.rst
@@ -1,0 +1,1 @@
+Git connection SSH key passphrases are now safely escaped before being exposed through ``SSH_ASKPASS``.

--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -21,6 +21,7 @@ import contextlib
 import json
 import logging
 import os
+import shlex
 import stat
 import tempfile
 from typing import Any
@@ -157,7 +158,7 @@ class GitHook(BaseHook):
             return
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=True) as askpass_script:
-            askpass_script.write(f"#!/bin/sh\necho '{self.private_key_passphrase}'\n")
+            askpass_script.write(f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(self.private_key_passphrase)}\n")
             askpass_script.flush()
             os.chmod(askpass_script.name, stat.S_IRWXU)
 

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 
 import pytest
 from git import Repo
@@ -352,3 +353,26 @@ class TestGitHook:
             assert os.path.exists(askpass_path)
         # Both the askpass script and the temp key file should be cleaned up
         assert not os.path.exists(askpass_path)
+
+    def test_passphrase_askpass_escapes_shell_metacharacters(self, create_connection_without_db, tmp_path):
+        marker = tmp_path / "askpass_injection_marker"
+        passphrase = f"x'; touch {marker}; echo '"
+        create_connection_without_db(
+            Connection(
+                conn_id="git_passphrase_escaped",
+                host=AIRFLOW_GIT,
+                conn_type="git",
+                extra={
+                    "key_file": "/files/pkey.pem",
+                    "private_key_passphrase": passphrase,
+                },
+            )
+        )
+
+        hook = GitHook(git_conn_id="git_passphrase_escaped")
+        with hook.configure_hook_env():
+            askpass_path = hook.env["SSH_ASKPASS"]
+            result = subprocess.run([askpass_path], check=True, capture_output=True, text=True)
+
+        assert result.stdout == f"{passphrase}\n"
+        assert not marker.exists()


### PR DESCRIPTION
### Motivation
- The temporary `SSH_ASKPASS` helper previously embedded raw passphrases into a shell script using an unescaped `echo`, allowing single quotes or shell metacharacters in a passphrase to inject commands when the script is executed.

### Description
- Replace writing `echo 'passphrase'` with a safe `printf '%s\n' {shlex.quote(passphrase)}` to avoid shell interpretation in the generated askpass script (`providers/git/src/airflow/providers/git/hooks/git.py`).
- Add a regression test that uses a passphrase containing embedded quotes and shell metacharacters, executes the generated askpass helper, asserts the exact passphrase is returned, and verifies no injected command ran (`providers/git/tests/unit/git/hooks/test_git.py`).
- Add a newsfragment describing the security hardening (`airflow-core/newsfragments/63942.bugfix.rst`).

### Testing
- Ran `ruff format` and `ruff check --fix` on the modified files, and those checks passed. 
- Performed `git diff --check` and committed the changes successfully as `Git: Escape SSH askpass passphrases`.
- Attempted to run the repository Breeze/prek-based test flow (e.g., `uv tool install prek`, `breeze run pytest`) but the environment could not reach external package/artifact hosts so pytest/Breeze bootstrap could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c100e8216c8331af428f2ca3657eb1)