### PR TITLE
Escape passphrase in SSH_ASKPASS script to prevent shell injection and add test

### DIFF
--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -21,6 +21,7 @@ import contextlib
 import json
 import logging
 import os
+import shlex
 import stat
 import tempfile
 from typing import Any
@@ -157,7 +158,7 @@ class GitHook(BaseHook):
             return
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=True) as askpass_script:
-            askpass_script.write(f"#!/bin/sh\necho '{self.private_key_passphrase}'\n")
+            askpass_script.write(f"#!/bin/sh\nprintf '%s\\n' {shlex.quote(self.private_key_passphrase)}\n")
             askpass_script.flush()
             os.chmod(askpass_script.name, stat.S_IRWXU)
 

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 
 import pytest
 from git import Repo
@@ -352,3 +353,26 @@ class TestGitHook:
             assert os.path.exists(askpass_path)
         # Both the askpass script and the temp key file should be cleaned up
         assert not os.path.exists(askpass_path)
+
+    def test_passphrase_askpass_escapes_shell_metacharacters(self, create_connection_without_db, tmp_path):
+        marker = tmp_path / "askpass_injection_marker"
+        passphrase = f"x'; touch {marker}; echo '"
+        create_connection_without_db(
+            Connection(
+                conn_id="git_passphrase_escaped",
+                host=AIRFLOW_GIT,
+                conn_type="git",
+                extra={
+                    "key_file": "/files/pkey.pem",
+                    "private_key_passphrase": passphrase,
+                },
+            )
+        )
+
+        hook = GitHook(git_conn_id="git_passphrase_escaped")
+        with hook.configure_hook_env():
+            askpass_path = hook.env["SSH_ASKPASS"]
+            result = subprocess.run([askpass_path], check=True, capture_output=True, text=True)
+
+        assert result.stdout == f"{passphrase}\n"
+        assert not marker.exists()


### PR DESCRIPTION
### Motivation
- Prevent potential shell injection when writing passphrase into the temporary `SSH_ASKPASS` helper script by ensuring the passphrase is safely quoted.
- Verify correct behavior with a unit test that includes shell metacharacters in the passphrase.

### Description
- Use `shlex.quote` and `printf '%s\n'` when writing the passphrase to the temporary askpass script to safely escape shell metacharacters.
- Add `import shlex` in the git hook implementation.
- Add a unit test `test_passphrase_askpass_escapes_shell_metacharacters` that runs the generated askpass script via `subprocess.run` to ensure the passphrase is returned verbatim and that no injected shell commands are executed.
- Add `import subprocess` to the test module and ensure cleanup assertions remain for temporary files.

### Testing
- Executed the updated unit test: `pytest providers/git/tests/unit/git/hooks/test_git.py::TestGitHook::test_passphrase_askpass_escapes_shell_metacharacters` and it passed.
- Ran the git hook test module `pytest providers/git/tests/unit/git/hooks/test_git.py` and all tests in the file passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c100e8216c8331af428f2ca3657eb1)