### PR TITLE
Keep Connection.extra serialized for URI constructor

### DIFF
--- a/airflow-core/newsfragments/connection-uri-extra.bugfix.rst
+++ b/airflow-core/newsfragments/connection-uri-extra.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Task SDK `Connection(uri=...)` so URI query parameters remain JSON-serialized in `extra`, avoiding crashes when serializing or reading extras.

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -151,7 +151,7 @@ class Connection:
         if uri is None:
             self.__attrs_init__(conn_id=conn_id, **kwargs)  # type: ignore[attr-defined]
         else:
-            self.__dict__.update(self.from_uri(uri, conn_id=conn_id).to_dict(validate=False))
+            self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
 
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -391,6 +391,15 @@ class TestConnectionFromUri:
         # uri should not exist as an attribute (it's init-only)
         assert not hasattr(conn, "uri")
 
+    def test_connection_constructor_with_uri_keeps_extra_serialized(self):
+        """Test Connection(uri=...) keeps extra as a JSON string."""
+        conn = Connection(conn_id="test_conn", uri="mysql://user:pass@host:3306/db?charset=utf8&timeout=30")
+
+        assert conn.extra == '{"charset": "utf8", "timeout": "30"}'
+        assert conn.extra_dejson == {"charset": "utf8", "timeout": "30"}
+        assert conn.to_dict()["extra"] == {"charset": "utf8", "timeout": "30"}
+        assert json.loads(conn.as_json())["extra"] == {"charset": "utf8", "timeout": "30"}
+
     def test_from_uri_roundtrip(self):
         """Test that from_uri and get_uri are inverse operations."""
         original_uri = "postgres://user:pass@host:5432/db?param1=value1&param2=value2"


### PR DESCRIPTION
### Motivation
- Fix a regression where `Connection(uri=...)` copied `to_dict()` output into `__dict__`, causing `extra` to become a `dict` instead of a JSON string and leading to `TypeError` in `extra_dejson`/serialization. 
- Ensure the URI constructor preserves the same field types as `from_uri()` so downstream calls to `extra_dejson`, `to_dict()`, and `as_json()` behave consistently.

### Description
- Replace the `to_dict()`-based copy with a raw attrs copy by using `attrs.asdict(..., recurse=False)` in the `Connection.__init__` URI path to preserve `extra` as a JSON string. 
- Add a regression test `test_connection_constructor_with_uri_keeps_extra_serialized` in `task-sdk/tests/task_sdk/definitions/test_connection.py` that verifies `extra`, `extra_dejson`, `to_dict()`, and `as_json()` for a URI with query parameters. 
- Add a newsfragment `airflow-core/newsfragments/connection-uri-extra.bugfix.rst` describing the bug fix.

### Testing
- Ran `ruff format` and `ruff check --fix` on the modified files and they completed successfully. 
- Verified Python syntax with `python -m py_compile` on the changed files and it succeeded. 
- Executed a targeted Python regression check that constructs `Connection(conn_id=..., uri=...)` and asserted `extra` remains a JSON string and round-trips through `extra_dejson`, `to_dict()`, and `as_json()`, and it passed. 
- Attempted to run the package test file with `uv run --project task-sdk pytest task-sdk/tests/task_sdk/definitions/test_connection.py` but full `pytest` startup failed in this environment due to an offline dependency/provider-generation step that requires network access, so full test suite execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16d2e4dc88331a035888e7bcaebd5)