### PR TITLE
Limit DataFusion result materialization in AnalyticsOperator

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -101,11 +101,13 @@ class DataFusionEngine(LoggingMixin):
             datasource_config.table_name,
         )
 
-    def execute_query(self, query: str) -> dict[str, list[Any]]:
+    def execute_query(self, query: str, max_rows: int | None = None) -> dict[str, list[Any]]:
         """Execute a query and return the result as a dictionary."""
         try:
             self.log.info("Executing query: %s", query)
             df = self.session_context.sql(query)
+            if max_rows is not None:
+                df = df.limit(max_rows)
             return df.to_pydict()
         except Exception as e:
             raise QueryExecutionException(f"Error while executing query: {e}")

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/analytics.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/analytics.py
@@ -89,7 +89,7 @@ class AnalyticsOperator(BaseOperator):
 
         # TODO make it parallel as there is no dependency between queries
         for query in self.queries:
-            result_dict = self._df_engine.execute_query(query)
+            result_dict = self._df_engine.execute_query(query, max_rows=self.max_rows_check + 1)
             results.append({"query": query, "data": result_dict})
 
         match self.result_output_format:
@@ -108,9 +108,9 @@ class AnalyticsOperator(BaseOperator):
         max_rows_exceeded = num_rows > self.max_rows_check
         if max_rows_exceeded:
             self.log.warning(
-                "Query returned %s rows, exceeding max_rows_check (%s). Skipping result output as large datasets are unsuitable for return.",
-                num_rows,
+                "Query returned more than max_rows_check (%s) rows. Only the first %s rows were fetched to avoid materializing the full result.",
                 self.max_rows_check,
+                self.max_rows_check + 1,
             )
         return max_rows_exceeded, num_rows
 
@@ -126,7 +126,7 @@ class AnalyticsOperator(BaseOperator):
             if too_large:
                 output_parts.append(
                     f"\n### Results: {query}\n\n"
-                    f"**Skipped**: {row_count} rows exceed max_rows_check ({self.max_rows_check})\n\n"
+                    f"**Skipped**: result exceeds max_rows_check ({self.max_rows_check})\n\n"
                     f"{'-' * 40}\n"
                 )
                 continue

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -150,6 +150,21 @@ class TestDataFusionEngine:
         engine.df_ctx.sql.assert_called_once_with("SELECT * FROM test_table")
         assert result == {"col1": [1, 2]}
 
+    def test_execute_query_with_max_rows(self):
+        engine = DataFusionEngine()
+        engine.df_ctx = MagicMock(spec=SessionContext)
+        mock_df = MagicMock(spec=["limit", "to_pydict"])
+        limited_df = MagicMock(spec=["to_pydict"])
+        limited_df.to_pydict.return_value = {"col1": [1, 2, 3]}
+        mock_df.limit.return_value = limited_df
+        engine.df_ctx.sql.return_value = mock_df
+
+        result = engine.execute_query("SELECT * FROM test_table", max_rows=3)
+
+        engine.df_ctx.sql.assert_called_once_with("SELECT * FROM test_table")
+        mock_df.limit.assert_called_once_with(3)
+        assert result == {"col1": [1, 2, 3]}
+
     def test_execute_query_failure(self):
         engine = DataFusionEngine()
         engine.df_ctx = MagicMock(spec=SessionContext)

--- a/providers/common/sql/tests/unit/common/sql/operators/test_analytics.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_analytics.py
@@ -53,7 +53,7 @@ class TestAnalyticsOperator:
         result = operator.execute(context={})
 
         mock_engine.register_datasource.assert_called_once()
-        mock_engine.execute_query.assert_called_once_with("SELECT * FROM users_data")
+        mock_engine.execute_query.assert_called_once_with("SELECT * FROM users_data", max_rows=101)
         assert "col1" in result
         assert "col2" in result
 
@@ -64,7 +64,7 @@ class TestAnalyticsOperator:
         result = operator.execute(context={})
 
         assert "Skipped" in result
-        assert "4 rows exceed max_rows_check (3)" in result
+        assert "result exceeds max_rows_check (3)" in result
 
     def test_json_output_format(self, mock_engine):
         datasource_config = DataSourceConfig(


### PR DESCRIPTION
### Motivation
- The `DataFusionEngine.execute_query` implementation called `df.to_pydict()` unconditionally, which materializes the entire query result in memory and allows large queries to exhaust worker memory (DoS) before `AnalyticsOperator` could enforce `max_rows_check`.
- The change aims to avoid full materialization of potentially large result sets by fetching a bounded number of rows from DataFusion and deciding whether to skip output based on that bound.

### Description
- Add an optional `max_rows: int | None` parameter to `DataFusionEngine.execute_query` and apply `df.limit(max_rows)` when provided to avoid materializing the full result before conversion to Python objects.
- Update `AnalyticsOperator.execute` to call `execute_query(query, max_rows=self.max_rows_check + 1)` so the operator can detect oversized results without loading the entire dataset into memory.
- Adjust warning and skip messages to reflect the bounded fetch behavior and avoid reporting an exact full-row count when the engine fetched only a limited subset.
- Add unit test `test_execute_query_with_max_rows` and update analytics operator tests to assert the operator passes `max_rows` to the engine and reflects the updated skip message.

### Testing
- Ran formatter and static checks with `ruff format` and `ruff check --fix` on the modified files, and they completed successfully.
- Attempted to run the provider unit tests with `uv run --project providers/common/sql pytest ...`, `uv run --project dev/breeze breeze run pytest ...`, and `pytest ...`, but those commands failed in this environment because Breeze/`uv` startup and dependency resolution require network access which is blocked here; no test failures related to the change were observed in this environment prior to the network-limited test run.
- Added focused unit tests that exercise the new bounded execution path (`test_execute_query_with_max_rows`) and updated operator tests to reflect the `max_rows` argument and message change; these tests are included in the diff and should pass in CI/normal developer environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11ce184588331ba93142e6f771b99)