### PR TITLE
Restrict DataFusion tool queries to configured tables

### DIFF
--- a/airflow-core/newsfragments/00000.bugfix.rst
+++ b/airflow-core/newsfragments/00000.bugfix.rst
@@ -1,0 +1,1 @@
+Restricted DataFusionToolset queries to only reference configured data source tables, preventing reads from arbitrary object-store URIs.

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
@@ -23,6 +23,10 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import ErrorLevel
+
 try:
     from airflow.providers.common.ai.utils.sql_validation import SQLSafetyError, validate_sql as _validate_sql
     from airflow.providers.common.sql.datafusion.engine import DataFusionEngine
@@ -110,6 +114,7 @@ class DataFusionToolset(AbstractToolset[Any]):
         if not datasource_configs:
             raise ValueError("datasource_configs must contain at least one DataSourceConfig")
         self._datasource_configs = datasource_configs
+        self._allowed_tables = frozenset(config.table_name for config in datasource_configs)
         self._allow_writes = allow_writes
         self._max_rows = max_rows
         self._engine: DataFusionEngine | None = None
@@ -194,6 +199,7 @@ class DataFusionToolset(AbstractToolset[Any]):
         try:
             if not self._allow_writes:
                 _validate_sql(sql)
+            self._validate_table_references(sql)
 
             engine = self._get_engine()
             pydict = engine.execute_query(sql)
@@ -219,6 +225,22 @@ class DataFusionToolset(AbstractToolset[Any]):
                     f"error: {ex!s}, Use get_schema and list_tables tools for more details."
                 ) from ex
             return json.dumps({"error": str(ex), "query": sql})
+
+    def _validate_table_references(self, sql: str) -> None:
+        """Ensure SQL only references DataSourceConfig-registered tables."""
+        try:
+            statements = sqlglot.parse(sql, error_level=ErrorLevel.RAISE)
+        except sqlglot.errors.ParseError as ex:
+            raise SQLSafetyError(f"SQL parse error: {ex}") from ex
+
+        for statement in (stmt for stmt in statements if stmt is not None):
+            for table in statement.find_all(exp.Table):
+                table_name = table.name
+                if table_name not in self._allowed_tables:
+                    raise SQLSafetyError(
+                        f"Table reference {table_name!r} is not allowed. Allowed tables: "
+                        f"{', '.join(sorted(self._allowed_tables))}"
+                    )
 
     @staticmethod
     def _is_retryable_query_error(error: QueryExecutionException) -> bool:

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
@@ -214,6 +214,42 @@ class TestDataFusionToolsetQuery:
                 )
             )
 
+    def test_blocks_queries_for_unconfigured_tables(self):
+        cfg = _make_mock_datasource_config("sales_data")
+        ts = DataFusionToolset([cfg])
+        engine = _make_mock_engine()
+        ts._engine = engine
+
+        with pytest.raises(SQLSafetyError, match="not allowed"):
+            asyncio.run(
+                ts.call_tool(
+                    "query",
+                    {"sql": "SELECT id FROM secret_data"},
+                    ctx=MagicMock(spec=RunContext),
+                    tool=MagicMock(spec=ToolsetTool),
+                )
+            )
+
+        engine.execute_query.assert_not_called()
+
+    def test_blocks_datafusion_table_functions(self):
+        cfg = _make_mock_datasource_config("sales_data")
+        ts = DataFusionToolset([cfg])
+        engine = _make_mock_engine()
+        ts._engine = engine
+
+        with pytest.raises(SQLSafetyError, match="read_csv"):
+            asyncio.run(
+                ts.call_tool(
+                    "query",
+                    {"sql": "SELECT * FROM read_csv('file:///etc/passwd')"},
+                    ctx=MagicMock(spec=RunContext),
+                    tool=MagicMock(spec=ToolsetTool),
+                )
+            )
+
+        engine.execute_query.assert_not_called()
+
     def test_allows_create_table_when_writes_enabled(self):
         cfg = _make_mock_datasource_config()
         ts = DataFusionToolset([cfg], allow_writes=True)


### PR DESCRIPTION
### Motivation
- The `DataFusionToolset` previously validated only top-level statement type and then executed arbitrary SELECTs, allowing DataFusion table functions (e.g. `read_csv('file:///…')`) to read arbitrary object-store URIs and local files, which is an information-disclosure risk. 

### Description
- Added an allowlist of configured table names derived from `DataSourceConfig.table_name` and stored it on initialization as `self._allowed_tables`.
- Enforced query-time table validation by calling a new helper `._validate_table_references(sql)` from `_query`, which parses SQL with `sqlglot.parse(..., ErrorLevel.RAISE)` and raises `SQLSafetyError` for any `exp.Table` that is not in `self._allowed_tables`.
- This validation blocks references to unregistered tables and DataFusion table-function URIs (e.g. `read_csv('file:///etc/passwd')`) before the engine executes the query.
- Added unit tests `test_blocks_queries_for_unconfigured_tables` and `test_blocks_datafusion_table_functions` to cover the new behavior and added a newsfragment documenting the hardening.

### Testing
- Attempted to run formatting with `uv run --project providers/common/ai ruff format` but the job failed in this environment due to an external wheel fetch error for `sphinx-airflow-theme`.
- Attempted `uv run --project providers/common/ai ruff check --fix` and `uv run --project providers/common/ai pytest providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py -xvs`, but both failed for the same blocked network fetch of the Airflow theme wheel.
- Unit tests covering the new validation were added to the test suite and should pass in CI where dependencies can be fetched successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c7e5f28c83318177f6385089f84e)