### PR TITLE
Enforce per-DAG RBAC for bulk task instance operations

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -27,6 +27,8 @@ from sqlalchemy import select, tuple_
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.datamodels.common import (
@@ -45,6 +47,7 @@ from airflow.api_fastapi.core_api.datamodels.task_instances import (
 from airflow.api_fastapi.core_api.security import GetUserDep
 from airflow.api_fastapi.core_api.services.public.common import BulkService
 from airflow.listeners.listener import get_listener_manager
+from airflow.models.dag import DagModel
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.utils.state import TaskInstanceState
@@ -211,6 +214,7 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         """
         specific_map_index_task_keys = set()
         all_map_index_task_keys = set()
+        dag_authorization_cache: dict[str, bool] = {}
 
         for entity in entities:
             dag_id, dag_run_id, task_id, map_index = self._extract_task_identifiers(entity)
@@ -225,6 +229,23 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
                     {
                         "error": error_msg,
                         "status_code": status.HTTP_400_BAD_REQUEST,
+                    }
+                )
+                continue
+
+            if dag_id not in dag_authorization_cache:
+                team_name = DagModel.get_team_name(dag_id, session=self.session)
+                dag_authorization_cache[dag_id] = get_auth_manager().is_authorized_dag(
+                    method="PUT",
+                    access_entity=DagAccessEntity.TASK_INSTANCE,
+                    details=DagDetails(id=dag_id, team_name=team_name),
+                    user=self.user,
+                )
+            if not dag_authorization_cache[dag_id]:
+                results.errors.append(
+                    {
+                        "error": f"User is not authorized to update task instances for DAG '{dag_id}'",
+                        "status_code": status.HTTP_403_FORBIDDEN,
                     }
                 )
                 continue

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -6141,6 +6141,57 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                     f"Expected map_index={mi} to remain running, got {ti.state!r}"
                 )
 
+    def test_bulk_task_instances_rejects_unauthorized_dag_ids_from_request_body(
+        self, test_client, session, default_ti
+    ):
+        self.create_task_instances(
+            session, task_instances=default_ti, dag_id=self.BASH_DAG_ID, update_extras=True
+        )
+        self.create_task_instances(session, task_instances=default_ti, dag_id=self.DAG_ID, update_extras=True)
+
+        mock_auth_manager = mock.MagicMock()
+        mock_auth_manager.is_authorized_dag.side_effect = lambda method, access_entity, details, user: (
+            details.id != self.BASH_DAG_ID
+        )
+
+        with mock.patch(
+            "airflow.api_fastapi.core_api.services.public.task_instances.get_auth_manager",
+            return_value=mock_auth_manager,
+        ):
+            response = test_client.patch(
+                self.WILDCARD_ENDPOINT,
+                json={
+                    "actions": [
+                        {
+                            "action": "update",
+                            "entities": [
+                                {
+                                    "dag_id": self.BASH_DAG_ID,
+                                    "dag_run_id": self.RUN_ID,
+                                    "task_id": self.BASH_TASK_ID,
+                                    "new_state": "success",
+                                },
+                                {
+                                    "dag_id": self.DAG_ID,
+                                    "dag_run_id": self.RUN_ID,
+                                    "task_id": self.TASK_ID,
+                                    "new_state": "success",
+                                },
+                            ],
+                        }
+                    ]
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["update"]["success"] == [f"{self.DAG_ID}.{self.RUN_ID}.{self.TASK_ID}[-1]"]
+        assert response.json()["update"]["errors"] == [
+            {
+                "error": f"User is not authorized to update task instances for DAG '{self.BASH_DAG_ID}'",
+                "status_code": 403,
+            }
+        ]
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.patch(self.ENDPOINT_URL, json={})
         assert response.status_code == 401

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -54,7 +54,7 @@ from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_runs,
-    clear_db_serialized_dags,
+    clear_db_teams,
     clear_rendered_ti_fields,
 )
 from tests_common.test_utils.logs import check_last_log
@@ -5511,22 +5511,11 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
 
     @pytest.fixture(autouse=True)
     def clean_db(self, session):
-        original_bundle_name = session.scalar(
-            select(DagModel.bundle_name).where(DagModel.dag_id == self.BASH_DAG_ID)
-        )
         clear_db_runs()
+        clear_db_teams()
         yield
-        session.rollback()
+        clear_db_teams()
         clear_db_runs()
-        clear_db_serialized_dags()
-        session.execute(
-            update(DagModel)
-            .where(DagModel.dag_id == self.BASH_DAG_ID)
-            .values(bundle_name=original_bundle_name)
-        )
-        session.execute(delete(DagBundleModel).where(DagBundleModel.name == self.RESTRICTED_BUNDLE_NAME))
-        session.execute(delete(Team).where(Team.name == self.RESTRICTED_TEAM_NAME))
-        session.commit()
 
     @pytest.mark.parametrize(
         ("default_ti", "actions", "expected_results", "endpoint_url", "setup_dags"),
@@ -6095,10 +6084,24 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
     ):
         # Setup task instances
         if setup_dags:
-            for dag_id in setup_dags:
+            if setup_dags == [self.BASH_DAG_ID, self.DAG_ID]:
                 self.create_task_instances(
-                    session, task_instances=default_ti, dag_id=dag_id, update_extras=True
+                    session,
+                    task_instances=[{"task_id": self.BASH_TASK_ID, "state": default_ti[0]["state"]}],
+                    dag_id=self.BASH_DAG_ID,
+                    update_extras=True,
                 )
+                self.create_task_instances(
+                    session,
+                    task_instances=[{"task_id": self.TASK_ID, "state": default_ti[1]["state"]}],
+                    dag_id=self.DAG_ID,
+                    update_extras=True,
+                )
+            else:
+                for dag_id in setup_dags:
+                    self.create_task_instances(
+                        session, task_instances=default_ti, dag_id=dag_id, update_extras=True
+                    )
         else:
             self.create_task_instances(session, task_instances=default_ti)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -26,18 +26,22 @@ from unittest import mock
 
 import pendulum
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import delete, func, select, update
 
 from airflow._shared.timezones.timezone import datetime
+from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.dagbag import DagBag, sync_bag_to_db
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
-from airflow.models import DagRun, Log, TaskInstance
+from airflow.models import DagModel, DagRun, Log, TaskInstance
 from airflow.models.dag_version import DagVersion
+from airflow.models.dagbundle import DagBundleModel
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskmap import TaskMap
+from airflow.models.team import Team
 from airflow.models.trigger import Trigger
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import BaseOperator, TaskGroup
@@ -50,6 +54,7 @@ from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_runs,
+    clear_db_serialized_dags,
     clear_rendered_ti_fields,
 )
 from tests_common.test_utils.logs import check_last_log
@@ -5501,6 +5506,27 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
     BASH_DAG_ID = "example_bash_operator"
     BASH_TASK_ID = "also_run_this"
     WILDCARD_ENDPOINT = "/dags/~/dagRuns/~/taskInstances"
+    RESTRICTED_BUNDLE_NAME = "restricted-bundle"
+    RESTRICTED_TEAM_NAME = "restricted-team"
+
+    @pytest.fixture(autouse=True)
+    def clean_db(self, session):
+        original_bundle_name = session.scalar(
+            select(DagModel.bundle_name).where(DagModel.dag_id == self.BASH_DAG_ID)
+        )
+        clear_db_runs()
+        yield
+        session.rollback()
+        clear_db_runs()
+        clear_db_serialized_dags()
+        session.execute(
+            update(DagModel)
+            .where(DagModel.dag_id == self.BASH_DAG_ID)
+            .values(bundle_name=original_bundle_name)
+        )
+        session.execute(delete(DagBundleModel).where(DagBundleModel.name == self.RESTRICTED_BUNDLE_NAME))
+        session.execute(delete(Team).where(Team.name == self.RESTRICTED_TEAM_NAME))
+        session.commit()
 
     @pytest.mark.parametrize(
         ("default_ti", "actions", "expected_results", "endpoint_url", "setup_dags"),
@@ -6141,24 +6167,48 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                     f"Expected map_index={mi} to remain running, got {ti.state!r}"
                 )
 
-    def test_bulk_task_instances_rejects_unauthorized_dag_ids_from_request_body(
-        self, test_client, session, default_ti
-    ):
+    def test_bulk_task_instances_rejects_unauthorized_dag_ids_from_request_body(self, test_client, session):
         self.create_task_instances(
-            session, task_instances=default_ti, dag_id=self.BASH_DAG_ID, update_extras=True
+            session,
+            task_instances=[{"task_id": self.BASH_TASK_ID, "state": State.RUNNING}],
+            dag_id=self.BASH_DAG_ID,
+            update_extras=True,
         )
-        self.create_task_instances(session, task_instances=default_ti, dag_id=self.DAG_ID, update_extras=True)
-
-        mock_auth_manager = mock.MagicMock()
-        mock_auth_manager.is_authorized_dag.side_effect = lambda method, access_entity, details, user: (
-            details.id != self.BASH_DAG_ID
+        self.create_task_instances(
+            session,
+            task_instances=[{"task_id": self.TASK_ID, "state": State.RUNNING}],
+            dag_id=self.DAG_ID,
+            update_extras=True,
         )
 
-        with mock.patch(
-            "airflow.api_fastapi.core_api.services.public.task_instances.get_auth_manager",
-            return_value=mock_auth_manager,
+        restricted_bundle = DagBundleModel(name=self.RESTRICTED_BUNDLE_NAME)
+        restricted_team = Team(name=self.RESTRICTED_TEAM_NAME)
+        restricted_bundle.teams.append(restricted_team)
+        session.add_all([restricted_bundle, restricted_team])
+
+        session.flush()
+        session.execute(
+            update(DagModel)
+            .where(DagModel.dag_id == self.BASH_DAG_ID)
+            .values(bundle_name=self.RESTRICTED_BUNDLE_NAME)
+        )
+        session.commit()
+
+        auth_manager = test_client.app.state.auth_manager
+        token = auth_manager._get_token_signer().generate(
+            auth_manager.serialize_user(
+                SimpleAuthManagerUser(username="limited-user", role="user", teams=[]),
+            )
+        )
+        with (
+            mock.patch("airflow.models.revoked_token.RevokedToken.is_revoked", return_value=False),
+            TestClient(
+                test_client.app,
+                headers={"Authorization": f"Bearer {token}"},
+                base_url=str(test_client.base_url),
+            ) as limited_test_client,
         ):
-            response = test_client.patch(
+            response = limited_test_client.patch(
                 self.WILDCARD_ENDPOINT,
                 json={
                     "actions": [


### PR DESCRIPTION
### Motivation
- A wildcard bulk endpoint allowed requests authenticated against `dag_id="~"` to modify task instances for DAG IDs provided in the request body, enabling cross-DAG RBAC bypass. 
- The change ensures authorization is validated per-target DAG when the request body supplies `dag_id`/`dag_run_id`, preserving team/DAG scoping.

### Description
- Added per-entity DAG authorization in `BulkTaskInstanceService._categorize_entities` by calling `get_auth_manager().is_authorized_dag` with `DagDetails(id=<dag_id>, team_name=<team_name>)`. 
- Looked up `team_name` with `DagModel.get_team_name` and cached authorization results per DAG to avoid repeated checks within the same request. 
- Unauthorized entities are now recorded as errors with HTTP 403 and skipped, while authorized entities in the same bulk request continue to be processed. 
- Added a regression unit test `test_bulk_task_instances_rejects_unauthorized_dag_ids_from_request_body` to `test_task_instances.py` that asserts unauthorized body-supplied DAG entries are rejected while authorized ones succeed.

### Testing
- Ran static formatting and lint fixes with `ruff format` and `ruff check --fix` on the modified files and they completed successfully. 
- A targeted unit test was added to `airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py` but full pytest execution was not performed here because `breeze` is required for running Airflow tests; attempt to run `breeze run pytest <test>` failed in this environment due to `breeze` not being installed. 
- Please run the new unit test in a developer environment using the recommended command: `breeze run pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py -k "bulk_task_instances_rejects_unauthorized_dag_ids_from_request_body" -xvs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c599b5a688833187b79ef9f86a5ae5)