### PR TITLE
Edge3: Prevent worker team spoofing during job fetch

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Body, Depends, status
+from fastapi import Body, Depends, HTTPException, status
 from sqlalchemy import select, update
 
 from airflow.api_fastapi.common.db.common import SessionDep  # noqa: TC001
@@ -33,6 +33,7 @@ try:
 except ImportError:
     DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
+from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel
 from airflow.providers.edge3.worker_api.auth import jwt_token_authorization_rest
 from airflow.providers.edge3.worker_api.datamodels import (
     EdgeJobFetched,
@@ -70,6 +71,10 @@ def fetch(
     session: SessionDep,
 ) -> EdgeJobFetched | None:
     """Fetch a job to execute on the edge worker."""
+    worker = session.scalar(select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name))
+    if not worker:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Worker not found")
+
     query = (
         select(EdgeJobModel)
         .where(
@@ -80,7 +85,7 @@ def fetch(
     )
     if body.queues:
         query = query.where(EdgeJobModel.queue.in_(body.queues))
-    query = query.where(EdgeJobModel.team_name == body.team_name)
+    query = query.where(EdgeJobModel.team_name == worker.team_name)
     query = query.limit(1)
     query = query.with_for_update(skip_locked=True)
     job: EdgeJobModel | None = session.scalar(query)

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
@@ -24,6 +24,7 @@ import pytest
 from sqlalchemy import delete, select
 
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
+from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWorkerState
 from airflow.providers.edge3.worker_api.datamodels import WorkerQueuesBody
 from airflow.providers.edge3.worker_api.routes.jobs import fetch, state
 from airflow.utils.session import create_session
@@ -136,6 +137,11 @@ class TestJobsApiRoutes:
 
     def test_fetch_filters_by_team_name(self, session: Session):
         with create_session() as session:
+            session.add(
+                EdgeWorkerModel(
+                    worker_name="worker1", state=EdgeWorkerState.IDLE, queues=[QUEUE], team_name="team_a"
+                )
+            )
             job_team_a = EdgeJobModel(
                 dag_id="dag_a",
                 task_id="task_a",
@@ -163,15 +169,20 @@ class TestJobsApiRoutes:
             session.add_all([job_team_a, job_team_b])
             session.commit()
 
-            body = WorkerQueuesBody(free_concurrency=1, queues=[QUEUE], team_name="team_a")
+            body = WorkerQueuesBody(free_concurrency=1, queues=[QUEUE], team_name="team_b")
             result = fetch("worker1", body, session)
             assert result is not None
             assert result.dag_id == "dag_a"
             assert result.task_id == "task_a"
 
     def test_fetch_without_team_name_returns_any_team(self, session: Session):
-        """When team_name is None, no team filter is applied so any queued job can be returned."""
+        """When a worker has no team_name, no team filter is applied so any queued job can be returned."""
         with create_session() as session:
+            session.add(
+                EdgeWorkerModel(
+                    worker_name="worker1", state=EdgeWorkerState.IDLE, queues=[QUEUE], team_name=None
+                )
+            )
             job_team_a = EdgeJobModel(
                 dag_id="dag_a",
                 task_id="task_a",


### PR DESCRIPTION
### Motivation
- The worker API previously used `team_name` supplied by the worker request to select jobs, allowing any holder of the shared token to impersonate another team and fetch/execute cross-team jobs.
- This change binds job selection to the server-side worker identity to restore multi-team isolation and prevent authorization bypass.

### Description
- Resolve the requesting worker from the DB in `fetch` and return `404` if the worker is unknown, instead of trusting `body.team_name` from the request.
- Use the persisted `worker.team_name` to filter `EdgeJobModel` rows when selecting jobs, and import `EdgeWorkerModel` and `HTTPException` to support this behavior.
- Update unit tests to insert a worker record before calling `fetch` and to verify forged `team_name` in request bodies is ignored while preserving the behavior when `worker.team_name` is `None` (global mode).

### Testing
- Ran `ruff format` and `ruff check --fix` on the modified files and they passed locally.
- Attempted to run the unit test file with `breeze run pytest` but `breeze` is not available in this environment, so the Breeze run was not executed.
- Attempted `uv run --project providers/edge3 pytest ...` but the run failed due to an external dependency fetch/network error for `sphinx-airflow-theme`, so pytest could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb7d1bf9488331bad0abbc589a896e)