### PR TITLE
Prevent cross-team Vault secret reads in multi-team mode

### DIFF
--- a/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
@@ -204,20 +204,21 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         """
         Get a secret from a team specific path or the global path.
 
-        If multi team is enabled, check {base_path}/{team_name}/{key}, then fallback to {base_path}/{global_path}/{key} or {base_path}/{key}.
+        If multi team is enabled, check {base_path}/{team_name}/{key}, then fallback to
+        {base_path}/{global_path}/{key} when ``global_secrets_path`` is configured.
         """
         if base_path is None:
             return None
-        if (
-            conf.getboolean("core", "multi_team", fallback=False)
-            and self.use_team_secrets_path
-            and team_name is not None
-        ):
+        is_multi_team = conf.getboolean("core", "multi_team", fallback=False)
+        if is_multi_team and self.use_team_secrets_path and team_name is not None:
             response = self._get_secret_with_base(self.build_path(base_path, team_name), key)
             if response is not None:
                 return response
+            if self.global_secrets_path is None:
+                return None
+
         # Fallback to global secret
-        if conf.getboolean("core", "multi_team", fallback=False) and self.global_secrets_path is not None:
+        if is_multi_team and self.global_secrets_path is not None:
             path = self.build_path(base_path, self.global_secrets_path)
         else:
             path = base_path

--- a/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
@@ -350,6 +350,45 @@ class TestVaultSecrets:
         )
         assert returned_uri == "world"
 
+
+    @conf_vars({("core", "multi_team"): "True"})
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_variable_value_multi_team_does_not_fallback_to_other_team_path(self, mock_hvac, secret_not_found):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        mock_client.secrets.kv.v2.read_secret_version.side_effect = [secret_not_found]
+
+        test_client = VaultBackend(variables_path="variables", mount_point="airflow")
+
+        returned_value = test_client.get_variable("team_b/db_password", team_name="team_a")
+
+        mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="variables/team_a/team_b/db_password",
+            mount_point="airflow",
+            version=None,
+            raise_on_deleted_version=True,
+        )
+        assert returned_value is None
+
+    @conf_vars({("core", "multi_team"): "True"})
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_connection_multi_team_does_not_fallback_to_other_team_path(self, mock_hvac, secret_not_found):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+        mock_client.secrets.kv.v2.read_secret_version.side_effect = [secret_not_found]
+
+        test_client = VaultBackend(connections_path="connections", mount_point="airflow")
+
+        returned_connection = test_client.get_connection("team_b/db_password", team_name="team_a")
+
+        mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="connections/team_a/team_b/db_password",
+            mount_point="airflow",
+            version=None,
+            raise_on_deleted_version=True,
+        )
+        assert returned_connection is None
+
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_variable_value_without_predefined_mount_point(self, mock_hvac):
         mock_client = mock.MagicMock()


### PR DESCRIPTION
### Motivation
- The Vault backend's multi-team fallback allowed a caller to request keys containing slashes (e.g. `other_team/secret`) and read another team's team-scoped secret because the fallback used `{base_path}/{key}` when `global_secrets_path` was unset.
- This path-confusion breaks intended team scoping and leaks confidentiality across teams in multi-team deployments.

### Description
- Change `_get_team_or_global_secret` to return `None` when a team-scoped lookup misses and `global_secrets_path` is not configured, preventing implicit fallback to `{base_path}/{key}` for multi-team lookups; the explicit global fallback remains when `global_secrets_path` is set (file: `providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py`).
- Add focused regression tests that assert a slash-containing key like `team_b/db_password` requested by `team_a` only attempts the `team_a/...` path and does not fall back to another team's path for both variables and connections (file: `providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py`).
- Keep previous behavior when `use_team_secrets_path` is disabled or when `global_secrets_path` is explicitly configured.

### Testing
- Ran `uv run ruff format` / `uv run ruff check --fix` for the touched files but the commands failed in this environment due to dependency fetch / network errors and could not complete.  (No other automated test suites were run here.)
- Added unit test cases (`test_get_variable_value_multi_team_does_not_fallback_to_other_team_path` and `test_get_connection_multi_team_does_not_fallback_to_other_team_path`) to cover the regression; these tests were committed with the change but not executed in this environment.

---
Drafted-by: Codex Assistant (2026-05) (no human review before posting)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b60fd3048331b933ad1918d9f7b7)