### PR TITLE
Mask Akeyless JWT in connection extras

### DIFF
--- a/providers/akeyless/provider.yaml
+++ b/providers/akeyless/provider.yaml
@@ -75,7 +75,7 @@ connection-types:
           type:
             - string
             - 'null'
-      jwt:
+      jwt_token:
         label: JWT
         schema:
           type:

--- a/providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py
+++ b/providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py
@@ -54,7 +54,7 @@ def get_provider_info():
                     "uid_token": {"label": "UID Token", "schema": {"type": ["string", "null"]}},
                     "gcp_audience": {"label": "GCP Audience", "schema": {"type": ["string", "null"]}},
                     "azure_object_id": {"label": "Azure Object ID", "schema": {"type": ["string", "null"]}},
-                    "jwt": {"label": "JWT", "schema": {"type": ["string", "null"]}},
+                    "jwt_token": {"label": "JWT", "schema": {"type": ["string", "null"]}},
                     "k8s_auth_config_name": {
                         "label": "K8s Auth Config Name",
                         "schema": {"type": ["string", "null"]},

--- a/providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py
+++ b/providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py
@@ -97,7 +97,7 @@ class AkeylessHook(BaseHook):
             body.cloud_id = self._get_cloud_id(access_type)
         elif access_type == "jwt":
             body.access_type = "jwt"
-            body.jwt = self._extra.get("jwt")
+            body.jwt = self._extra.get("jwt_token") or self._extra.get("jwt")
         elif access_type == "k8s":
             body.access_type = "k8s"
             body.k8s_auth_config_name = self._extra.get("k8s_auth_config_name")
@@ -211,7 +211,7 @@ class AkeylessHook(BaseHook):
             "uid_token": StringField(lazy_gettext("UID Token"), widget=BS3TextFieldWidget()),
             "gcp_audience": StringField(lazy_gettext("GCP Audience"), widget=BS3TextFieldWidget()),
             "azure_object_id": StringField(lazy_gettext("Azure Object ID"), widget=BS3TextFieldWidget()),
-            "jwt": StringField(lazy_gettext("JWT"), widget=BS3TextFieldWidget()),
+            "jwt_token": StringField(lazy_gettext("JWT"), widget=BS3TextFieldWidget()),
             "k8s_auth_config_name": StringField(
                 lazy_gettext("K8s Auth Config Name"), widget=BS3TextFieldWidget()
             ),

--- a/providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py
+++ b/providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py
@@ -191,6 +191,37 @@ class TestAkeylessHook:
         with pytest.raises(ValueError, match="Unsupported access_type"):
             hook.authenticate()
 
+
+    @patch(
+        f"{HOOK_MODULE}.AkeylessHook.get_connection",
+        return_value=_make_connection(extra='{"access_type": "jwt", "jwt_token": "jwt-token-value"}'),
+    )
+    @patch(f"{HOOK_MODULE}.akeyless")
+    def test_jwt_auth_uses_jwt_token_extra(self, mock_sdk, mock_conn):
+        api = mock_sdk.V2Api.return_value
+        api.auth.return_value = MagicMock(token="t")
+        from airflow.providers.akeyless.hooks.akeyless import AkeylessHook
+
+        hook = AkeylessHook()
+        hook.authenticate()
+        auth_body = api.auth.call_args.args[0]
+        assert auth_body.jwt == "jwt-token-value"
+
+    @patch(
+        f"{HOOK_MODULE}.AkeylessHook.get_connection",
+        return_value=_make_connection(extra='{"access_type": "jwt", "jwt": "legacy-jwt-value"}'),
+    )
+    @patch(f"{HOOK_MODULE}.akeyless")
+    def test_jwt_auth_supports_legacy_jwt_extra(self, mock_sdk, mock_conn):
+        api = mock_sdk.V2Api.return_value
+        api.auth.return_value = MagicMock(token="t")
+        from airflow.providers.akeyless.hooks.akeyless import AkeylessHook
+
+        hook = AkeylessHook()
+        hook.authenticate()
+        auth_body = api.auth.call_args.args[0]
+        assert auth_body.jwt == "legacy-jwt-value"
+
     @patch(f"{HOOK_MODULE}.AkeylessHook.get_connection", return_value=_make_connection())
     @patch(f"{HOOK_MODULE}.akeyless")
     def test_get_rotated_secret_passes_list(self, mock_sdk, mock_conn):


### PR DESCRIPTION
### Motivation
- Airflow's default secrets redaction does not consider a bare `jwt` extra key sensitive, which causes Akeyless JWT credentials stored in connection `extra` to be returned unmasked via the API/UI; this exposes reusable authentication credentials to users who can read connections.

### Description
- Rename the Akeyless connection extra key from `jwt` to `jwt_token` in provider metadata and generated provider info so it matches Airflow's default sensitive-key substrings and is redacted by default. (`providers/akeyless/provider.yaml`, `providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py`).
- Update the hook to use `self._extra.get("jwt_token")` and fall back to legacy `self._extra.get("jwt")` to preserve compatibility for existing connections. (`providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py`).
- Add unit tests that assert the hook uses the new `jwt_token` extra and still accepts the legacy `jwt` key. (`providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py`).

### Testing
- Added unit tests covering the new `jwt_token` behavior and the legacy `jwt` fallback, and committed the changes to the branch; the tests are included in `providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py` and should run in CI.
- Attempts to run `uv run --project providers/akeyless pytest providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py -xvs` and `uv run ruff ...` in this environment failed due to a network/dependency fetch error (unable to download `sphinx-airflow-theme`), so I could not execute the suite here; CI should run the tests and linters successfully.

---
Drafted-by: GPT-5.3-Codex (no human review before posting)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11add373008331b0ea61287a4018e1)