### PR TITLE
Rename Akeyless JWT extra field to `jwt_token` and update usages/tests

### DIFF
--- a/providers/akeyless/provider.yaml
+++ b/providers/akeyless/provider.yaml
@@ -75,7 +75,7 @@ connection-types:
           type:
             - string
             - 'null'
-      jwt:
+      jwt_token:
         label: JWT
         schema:
           type:

--- a/providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py
+++ b/providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py
@@ -54,7 +54,7 @@ def get_provider_info():
                     "uid_token": {"label": "UID Token", "schema": {"type": ["string", "null"]}},
                     "gcp_audience": {"label": "GCP Audience", "schema": {"type": ["string", "null"]}},
                     "azure_object_id": {"label": "Azure Object ID", "schema": {"type": ["string", "null"]}},
-                    "jwt": {"label": "JWT", "schema": {"type": ["string", "null"]}},
+                    "jwt_token": {"label": "JWT", "schema": {"type": ["string", "null"]}},
                     "k8s_auth_config_name": {
                         "label": "K8s Auth Config Name",
                         "schema": {"type": ["string", "null"]},

--- a/providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py
+++ b/providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py
@@ -97,7 +97,7 @@ class AkeylessHook(BaseHook):
             body.cloud_id = self._get_cloud_id(access_type)
         elif access_type == "jwt":
             body.access_type = "jwt"
-            body.jwt = self._extra.get("jwt")
+            body.jwt = self._extra.get("jwt_token")
         elif access_type == "k8s":
             body.access_type = "k8s"
             body.k8s_auth_config_name = self._extra.get("k8s_auth_config_name")
@@ -211,7 +211,7 @@ class AkeylessHook(BaseHook):
             "uid_token": StringField(lazy_gettext("UID Token"), widget=BS3TextFieldWidget()),
             "gcp_audience": StringField(lazy_gettext("GCP Audience"), widget=BS3TextFieldWidget()),
             "azure_object_id": StringField(lazy_gettext("Azure Object ID"), widget=BS3TextFieldWidget()),
-            "jwt": StringField(lazy_gettext("JWT"), widget=BS3TextFieldWidget()),
+            "jwt_token": StringField(lazy_gettext("JWT"), widget=BS3TextFieldWidget()),
             "k8s_auth_config_name": StringField(
                 lazy_gettext("K8s Auth Config Name"), widget=BS3TextFieldWidget()
             ),

--- a/providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py
+++ b/providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py
@@ -191,6 +191,21 @@ class TestAkeylessHook:
         with pytest.raises(ValueError, match="Unsupported access_type"):
             hook.authenticate()
 
+    @patch(
+        f"{HOOK_MODULE}.AkeylessHook.get_connection",
+        return_value=_make_connection(extra='{"access_type": "jwt", "jwt_token": "jwt-token-value"}'),
+    )
+    @patch(f"{HOOK_MODULE}.akeyless")
+    def test_jwt_auth_uses_jwt_token_extra(self, mock_sdk, mock_conn):
+        api = mock_sdk.V2Api.return_value
+        api.auth.return_value = MagicMock(token="t")
+        from airflow.providers.akeyless.hooks.akeyless import AkeylessHook
+
+        hook = AkeylessHook()
+        hook.authenticate()
+        auth_body = api.auth.call_args.args[0]
+        assert auth_body.jwt == "jwt-token-value"
+
     @patch(f"{HOOK_MODULE}.AkeylessHook.get_connection", return_value=_make_connection())
     @patch(f"{HOOK_MODULE}.akeyless")
     def test_get_rotated_secret_passes_list(self, mock_sdk, mock_conn):


### PR DESCRIPTION
### Motivation
- Standardize the Akeyless connection extra key for JWT from `jwt` to `jwt_token` to avoid ambiguity and align naming across provider metadata, UI, and hook implementation.

### Description
- Renamed the connection extra field in `providers/akeyless/provider.yaml` from `jwt` to `jwt_token`.
- Updated provider metadata in `get_provider_info.py` to use `jwt_token` for the `conn-fields` entry.
- Updated the hook implementation in `hooks/akeyless.py` to read `jwt` from `self._extra.get("jwt_token")` and to expose `jwt_token` via `get_connection_form_widgets`.
- Adjusted unit tests in `tests/unit/akeyless/hooks/test_akeyless.py` to assert that JWT authentication uses the `jwt_token` extra and added `test_jwt_auth_uses_jwt_token_extra`.

### Testing
- Ran the modified unit tests in `providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py`, including `test_jwt_auth_uses_jwt_token_extra`, and they passed.
- Existing Akeyless hook tests (e.g. `test_invalid_access_type_raises`, `test_delete_item`, `test_get_rotated_secret_passes_list`) were executed and passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11add373008331b0ea61287a4018e1)