### PR TITLE
Validate Java coordinator TCP clients

### DIFF
--- a/task-sdk/src/airflow/sdk/coordinators/java/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/java/coordinator.py
@@ -32,6 +32,7 @@ import zipfile
 from typing import TYPE_CHECKING, TypeVar, cast
 
 import attrs
+import psutil
 import structlog
 
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
@@ -143,6 +144,31 @@ class _JarInfo:
         raise FileNotFoundError(tp.format(main_class, os.pathsep.join(os.fspath(p.resolve()) for p in roots)))
 
 
+def _socket_address(value: tuple | str) -> tuple[str, int] | None:
+    if not isinstance(value, tuple) or len(value) < 2:
+        return None
+    host, port = value[:2]
+    return str(host), int(port)
+
+
+def _is_connection_from_process(conn: socket.socket, proc: subprocess.Popen) -> bool:
+    """Return whether the accepted TCP connection belongs to the child process."""
+    peer = _socket_address(conn.getpeername())
+    local = _socket_address(conn.getsockname())
+    if peer is None or local is None:
+        return False
+    try:
+        process = psutil.Process(proc.pid)
+        connections = process.net_connections(kind="tcp")
+    except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError):
+        log.warning("Unable to verify child process connection", pid=proc.pid, exc_info=True)
+        return False
+    for connection in connections:
+        if _socket_address(connection.laddr) == peer and _socket_address(connection.raddr) == local:
+            return True
+    return False
+
+
 def _accept_connections(
     servers: dict[str, socket.socket],
     drains: dict[str, socket.socket],
@@ -180,6 +206,15 @@ def _accept_connections(
                 else:
                     log.debug("Accepting child process connection", key=event.data)
                     conn, _ = soc.accept()
+                    if not _is_connection_from_process(conn, proc):
+                        log.warning(
+                            "Rejected connection not owned by child process",
+                            key=event.data,
+                            pid=proc.pid,
+                            peer=conn.getpeername(),
+                        )
+                        conn.close()
+                        continue
                     sel.unregister(soc)
                     accepted[soc] = conn
     return accepted, drained

--- a/task-sdk/tests/task_sdk/coordinators/java/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/java/test_coordinator.py
@@ -36,6 +36,7 @@ from airflow.sdk.coordinators.java.coordinator import (
     JavaCoordinator,
     _accept_connections,
     _calculate_classpath,
+    _is_connection_from_process,
     _JarInfo,
     _JavaActivitySubprocess,
     _ResourceTracker,
@@ -216,6 +217,14 @@ class TestMainJar:
 
 
 class TestAcceptConnections:
+    @pytest.fixture(autouse=True)
+    def mock_child_connection_check(self):
+        with patch(
+            "airflow.sdk.coordinators.java.coordinator._is_connection_from_process",
+            return_value=True,
+        ) as mock_check:
+            yield mock_check
+
     def _connect_after_delay(self, addr: tuple[str, int], delay: float = 0.0) -> None:
         def _connect():
             time.sleep(delay)
@@ -367,6 +376,61 @@ class TestAcceptConnections:
             assert "comm" not in accepted
             accepted[server].close()
         finally:
+            server.close()
+
+    def test_rejects_connections_not_owned_by_child_process(self, mock_child_connection_check):
+        server = _start_server()
+        _, port = server.getsockname()
+        mock_child_connection_check.side_effect = [False, True]
+        self._connect_after_delay(("127.0.0.1", port))
+        self._connect_after_delay(("127.0.0.1", port), delay=0.05)
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+
+        try:
+            accepted, _ = _accept_connections({"comm": server}, {}, mock_proc)
+            assert mock_child_connection_check.call_count == 2
+            assert server in accepted
+            accepted[server].close()
+        finally:
+            server.close()
+
+
+class TestConnectionFromProcess:
+    def test_matches_child_process_tcp_connection(self):
+        server = _start_server()
+        _, port = server.getsockname()
+        client = socket.socket()
+        client.connect(("127.0.0.1", port))
+        conn, _ = server.accept()
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = os.getpid()
+
+        try:
+            assert _is_connection_from_process(conn, mock_proc) is True
+        finally:
+            conn.close()
+            client.close()
+            server.close()
+
+    def test_rejects_tcp_connection_not_owned_by_child_process(self):
+        server = _start_server()
+        _, port = server.getsockname()
+        client = socket.socket()
+        client.connect(("127.0.0.1", port))
+        conn, _ = server.accept()
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = os.getpid()
+
+        try:
+            with patch("airflow.sdk.coordinators.java.coordinator.psutil.Process") as mock_process:
+                mock_process.return_value.net_connections.return_value = []
+                assert _is_connection_from_process(conn, mock_proc) is False
+        finally:
+            conn.close()
+            client.close()
             server.close()
 
 


### PR DESCRIPTION
### Motivation

- The Java coordinator accepted the first loopback TCP client and exposed the supervisor channel without authenticating or verifying the peer, allowing a local process to race and hijack task-scoped operations.

### Description

- Add a TCP connection ownership check using `psutil.Process().net_connections()` via a new helper `_is_connection_from_process` and supporting `_socket_address` helper in `task-sdk/src/airflow/sdk/coordinators/java/coordinator.py`.
- Reject and close accepted sockets that cannot be proven to belong to the spawned Java subprocess before binding them into the supervisor communication path in `_accept_connections`.
- Import `psutil` and log a warning when verification cannot be performed due to errors or access restrictions.
- Add unit tests in `task-sdk/tests/task_sdk/coordinators/java/test_coordinator.py` that exercise rejecting non-child connections and verifying the `_is_connection_from_process` helper, and introduce an autouse fixture to mock the child-connection check for existing accept-path tests.

### Testing

- Ran `ruff format` and `ruff check --fix` on the modified files, and linting/formatting checks passed.
- Attempted to run the coordinator unit tests via `uv run --project task-sdk pytest ...` and `pytest ...`, but test runs were blocked by repository toolchain network dependency downloads (external artifacts needed by the test harness), so the updated tests were added but full pytest execution in this environment could not complete.
- Added tests are: `task-sdk/tests/task_sdk/coordinators/java/test_coordinator.py::TestAcceptConnections::test_rejects_connections_not_owned_by_child_process` and `task-sdk/tests/task_sdk/coordinators/java/test_coordinator.py::TestConnectionFromProcess`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b1b5b2248331b699d75a53d7781d)