### PR TITLE
Fix JDBC OpenLineage credential sanitization

### DIFF
--- a/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
+++ b/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
@@ -332,15 +332,23 @@ class JdbcHook(DbApiHook):
                 # Non-standard JDBC URL we can't reliably parse (e.g. Oracle
                 # SID format ``thin:@host:port:sid``, H2 ``mem:test``).
                 return None
+            # Strip userinfo before handling path, query string, or driver-specific
+            # option separators. Some drivers accept raw delimiters in userinfo;
+            # stripping delimiters first could leave credentials in the authority.
+            after = JdbcHook._strip_openlineage_userinfo(after)
             # Strip path, query string, and driver-specific option separator
             # (e.g. SQL Server uses ``;`` for connection properties).
             for sep in ("/", "?", ";"):
                 after = after.split(sep, 1)[0]
-            # Strip userinfo (some drivers accept ``user:pass@host:port`` in the
-            # URL); we never want credentials leaking into the OL namespace.
-            if "@" in after:
-                after = after.rsplit("@", 1)[-1]
             return after or None
+        host = JdbcHook._strip_openlineage_userinfo(host)
         if connection.port and host:
             return f"{host}:{connection.port}"
         return host or None
+
+    @staticmethod
+    def _strip_openlineage_userinfo(authority: str) -> str:
+        """Remove embedded URL userinfo from an OpenLineage authority candidate."""
+        if "@" in authority:
+            return authority.rsplit("@", 1)[-1]
+        return authority

--- a/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
+++ b/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
@@ -599,6 +599,11 @@ class TestJdbcHookOpenLineage:
             # Userinfo embedded in URL (legal for several drivers) is stripped
             # so credentials never leak into the OL namespace
             ("jdbc:postgresql://user:pass@pg-host:5432/mydb", None, "pg-host:5432"),
+            # Strip userinfo before driver-specific option separators so raw
+            # delimiters in credentials are never emitted in the OL namespace.
+            ("jdbc:postgresql://user:secret;ssl=true@pg-host:5432/mydb", None, "pg-host:5432"),
+            # Plain host fallback should also strip embedded userinfo.
+            ("user:secret@plain-host", 5432, "plain-host:5432"),
             # ``jdbc:`` prefix is case-insensitive per the JDBC spec
             ("JDBC:postgresql://pg-host:5432/mydb", None, "pg-host:5432"),
         ],


### PR DESCRIPTION
### Motivation
- Prevent credentials embedded in JDBC URLs from being emitted as the OpenLineage authority/namespace when URL userinfo contains raw delimiters (for example `;`) that the previous parser removed before stripping userinfo.
- Address a parsing-order bug where path/query/option separators were stripped before userinfo, allowing credential fragments to become the reported authority.

### Description
- In `JdbcHook._get_openlineage_authority` strip URL userinfo first using a new static helper `JdbcHook._strip_openlineage_userinfo` before removing path, query, or driver-specific option separators.
- Apply the same userinfo stripping to the plain host fallback so `host` values containing embedded userinfo are sanitized before forming `host:port` authority strings.
- Add regression coverage in `providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py` for JDBC userinfo containing delimiters (e.g. `user:secret;ssl=true@...`) and for plain-host userinfo fallback cases.
- Run `ruff` formatting/checks on the modified files to obey repository style rules.

### Testing
- Ran `ruff` formatting and `ruff check --fix` on the changed files and they succeeded.
- Verified `git diff --check` with no issues reported.
- Attempted to run the targeted unit test `providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py::TestJdbcHookOpenLineage::test_get_openlineage_authority_extraction` via the repository test runner, but execution was blocked by network failures fetching external build/provider dependencies so the pytest run did not complete in this environment.
- A regression test was added that expresses the failing input and should pass with this fix when the full test environment (with network access for dependency setup) is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae163057883319d0b560026332404)