### PR TITLE
Quote `dag_id` in Task SDK Get to prevent path traversal

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from functools import cache
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeVar
+from urllib.parse import quote
 
 import certifi
 import httpx
@@ -977,7 +978,7 @@ class DagsOperations:
 
     def get(self, dag_id: str) -> DagResponse:
         """Get a DAG via the API server."""
-        resp = self.client.get(f"dags/{dag_id}")
+        resp = self.client.get(f"dags/{quote(dag_id, safe='')}")
         return DagResponse.model_validate_json(resp.read())
 
 

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1740,9 +1740,15 @@ class TestDagsOperations:
     def test_get_url_quotes_dag_id_as_single_path_segment(self):
         """Test that Dag IDs cannot escape the dags API path."""
         requests_seen = []
+        crafted_dag_id = "x/../../variables/secret_key"
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             requests_seen.append(request)
+            if request.url.path == "/variables/secret_key":
+                return httpx.Response(
+                    status_code=200,
+                    json={"key": "secret_key", "value": "super-secret-value"},
+                )
             return httpx.Response(
                 status_code=404,
                 json={
@@ -1755,10 +1761,12 @@ class TestDagsOperations:
 
         client = make_client(transport=httpx.MockTransport(handle_request))
 
-        with pytest.raises(ServerResponseError):
-            client.dags.get(dag_id="x/../../variables/secret_key")
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.dags.get(dag_id=crafted_dag_id)
 
         assert requests_seen[0].url.raw_path == b"/dags/x%2F..%2F..%2Fvariables%2Fsecret_key"
+        assert requests_seen[0].url.path != "/variables/secret_key"
+        assert "super-secret-value" not in str(exc_info.value)
 
     def test_get_not_found(self):
         """Test that getting a missing dag raises a server response error."""

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1737,6 +1737,29 @@ class TestDagsOperations:
             next_dagrun=datetime(2026, 4, 13, tzinfo=dt_timezone.utc),
         )
 
+    def test_get_url_quotes_dag_id_as_single_path_segment(self):
+        """Test that Dag IDs cannot escape the dags API path."""
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                status_code=404,
+                json={
+                    "detail": {
+                        "message": "The Dag was not found",
+                        "reason": "not_found",
+                    }
+                },
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+
+        with pytest.raises(ServerResponseError):
+            client.dags.get(dag_id="x/../../variables/secret_key")
+
+        assert requests_seen[0].url.raw_path == b"/dags/x%2F..%2F..%2Fvariables%2Fsecret_key"
+
     def test_get_not_found(self):
         """Test that getting a missing dag raises a server response error."""
 


### PR DESCRIPTION
### Motivation
- Prevent templated `trigger_dag_id` from escaping the `/dags/` Execution API path by ensuring the task SDK treats `dag_id` as a single URL path segment.

### Description
- Percent-encode `dag_id` in `DagsOperations.get` by using `urllib.parse.quote(dag_id, safe='')` in `task-sdk/src/airflow/sdk/api/client.py` and add a regression test `test_get_url_quotes_dag_id_as_single_path_segment` in `task-sdk/tests/task_sdk/api/test_client.py` that asserts the request `raw_path` is the percent-encoded `/dags/` segment.

### Testing
- Ran `ruff format` and `ruff check --fix` on the modified files successfully and added a unit test demonstrating the encoded path behavior; running the test suite with `uv run --project task-sdk pytest ...` was attempted but test execution was blocked by network dependency download failures in this environment.

---
Drafted-by: GPT-5.3-Codex (no human review before posting)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0bd90914833194bf0f7c1d605f30)