### PR TITLE
Fix Spark K8s driver pod tracking confusion

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -53,6 +53,9 @@ DEFAULT_SPARK_BINARY = "spark-submit"
 ALLOWED_SPARK_BINARIES = [DEFAULT_SPARK_BINARY, "spark2-submit", "spark3-submit"]
 
 _K8S_WAIT_APP_COMPLETION_CONF = "spark.kubernetes.submission.waitAppCompletion"
+_K8S_DRIVER_POD_NAME_REGEX = re.compile(
+    r"(?:^|\s)submission ID spark:([a-z0-9](?:[-a-z0-9]*[a-z0-9])?-driver)(?=\s|$)"
+)
 
 
 class SparkSubmitHook(BaseHook, LoggingMixin):
@@ -841,7 +844,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     self._kubernetes_driver_pod = match_driver_pod.group(1)
                     self.log.info("Identified spark driver pod: %s", self._kubernetes_driver_pod)
                 if not self._kubernetes_driver_pod:
-                    match_submission_id = re.search(r"submission ID spark:(.+?-driver)", line)
+                    match_submission_id = _K8S_DRIVER_POD_NAME_REGEX.search(line)
                     if match_submission_id:
                         self._kubernetes_driver_pod = match_submission_id.group(1)
                         self.log.info("Identified spark driver pod: %s", self._kubernetes_driver_pod)
@@ -1141,11 +1144,10 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     consecutive_api_errors = 0
                 except kube_client.ApiException as e:
                     if e.status == 404:
-                        self.log.info(
-                            "Driver pod %s not found (404); pod was likely deleted by on_kill. Exiting poll loop.",
-                            pod_name,
-                        )
-                        return
+                        raise RuntimeError(
+                            f"K8s driver pod {pod_name} was not found while polling {app_id}; "
+                            "cannot determine Spark application status."
+                        ) from e
                     consecutive_api_errors += 1
                     self.log.warning(
                         "ApiException polling pod %s (%d/%d): %s",

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -941,17 +941,24 @@ class TestSparkSubmitHook:
         # Then
         assert hook._spark_exit_code == 999
 
-    def test_process_spark_submit_log_k8s_submission_id_format(self):
+    @pytest.mark.parametrize(
+        "pod_name",
+        [
+            "arrow-spark-c8e2e29e73db9c93-driver",
+            "victim-driver-foo-abc-driver",
+        ],
+    )
+    def test_process_spark_submit_log_k8s_submission_id_format(self, pod_name):
         hook = SparkSubmitHook(conn_id="spark_k8s_cluster")
         log_lines = [
-            "INFO Client: Deployed Spark application arrow-spark with application ID "
+            f"INFO Client: Deployed Spark application {pod_name.removesuffix('-driver')} with application ID "
             "spark-1e22d65826b74ac2927249b0e607ed54 and submission ID "
-            "spark:arrow-spark-c8e2e29e73db9c93-driver into Kubernetes",
+            f"spark:{pod_name} into Kubernetes",
         ]
 
         hook._process_spark_submit_log(log_lines)
 
-        assert hook._kubernetes_driver_pod == "arrow-spark-c8e2e29e73db9c93-driver"
+        assert hook._kubernetes_driver_pod == pod_name
 
     def test_process_spark_client_mode_submit_log_k8s(self):
         # Given
@@ -1589,8 +1596,8 @@ class TestSparkSubmitHook:
         assert mock_client.read_namespaced_pod.call_count == 3
 
     @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
-    def test_poll_k8s_driver_exits_cleanly_on_404(self, mock_get_client):
-        """404 from read_namespaced_pod means pod was deleted by on_kill — should return cleanly, not raise."""
+    def test_poll_k8s_driver_raises_on_404(self, mock_get_client):
+        """404 from read_namespaced_pod means the submitted driver cannot be tracked."""
         hook = SparkSubmitHook(conn_id="spark_k8s_cluster", track_driver_via_k8s_api=True)
         hook._kubernetes_driver_pod = "spark-app-abc-driver"
         hook._kubernetes_application_id = "spark-abc"
@@ -1598,7 +1605,8 @@ class TestSparkSubmitHook:
         mock_client = mock_get_client.return_value
         mock_client.read_namespaced_pod.side_effect = kube_client.ApiException(status=404, reason="Not Found")
 
-        hook._poll_k8s_driver_via_api()
+        with pytest.raises(RuntimeError, match="was not found"):
+            hook._poll_k8s_driver_via_api()
 
         mock_client.delete_namespaced_pod.assert_not_called()
 


### PR DESCRIPTION
### Motivation
- The K8s API tracking path parsed spark-submit output with a loose regex that could truncate pod names at the first `-driver`, allowing a crafted Spark name to point to an unrelated pod. 
- The parsed pod name was trusted for reads/deletes and a 404 during polling was treated as a clean exit, enabling false-success and unintended pod deletion. 
- The change aims to harden parsing and make polling fail-closed so the submitted driver cannot be spoofed by user-controlled application names.

### Description
- Add a strict driver pod-name pattern `_K8S_DRIVER_POD_NAME_REGEX` and use it to extract a complete driver pod name from `submission ID spark:...` log lines. 
- Replace the previous permissive `re.search(r"submission ID spark:(.+?-driver)")` usage with the compiled regex to avoid truncation when the app name itself contains `-driver`. 
- Change K8s polling behavior so a `404` from `read_namespaced_pod` raises a `RuntimeError` instead of returning cleanly, preventing false-success when the parsed pod is missing. 
- Update unit tests to cover a submission ID whose app-derived name contains `-driver` and to assert the new `404`-as-error behavior.

### Testing
- Ran formatter/linter checks: `ruff format` and `ruff check --fix` on the modified files, which completed successfully. 
- Updated and ran the targeted unit tests locally via the providers test runner; test execution in this environment failed to collect due to a missing `kubernetes` test dependency and network issues when resolving the test environment, so full pytest runs could not be completed here. 
- Verified the repository diff and updated tests cover the vulnerability scenario and new 404 behavior; further CI runs in the project environment with the `kubernetes` package available are required to validate runtime test execution. 

Drafted-by: GPT-5.5 (no human review before posting)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a234ac864548331805618cf6a133973)